### PR TITLE
fix: 使用を避けたほうがよい文字でトレーナー名を送信可能

### DIFF
--- a/pages/new.vue
+++ b/pages/new.vue
@@ -17,11 +17,11 @@ export default {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          name: trainerName.value,
+          name: safeTrainerName.value,
         }),
       });
       if (!response.ok) return;
-      router.push(`/trainer/${trainerName.value}`);
+      router.push(`/trainer/${safeTrainerName.value}`);
     };
     const { dialog, onOpen, onClose } = useDialog();
     return {


### PR DESCRIPTION
加工済みの値を送信時の値として用いていなかったことが原因