### PR TITLE
fix: clickがネイティブイベントとカスタムイベントの2回呼ばれている

### DIFF
--- a/components/GamifyButton.vue
+++ b/components/GamifyButton.vue
@@ -1,18 +1,13 @@
 <template>
-  <button class="gamify-button" @click="buttonClicked()">
+  <button class="gamify-button">
     <slot />
   </button>
 </template>
 
 <script>
 export default {
-  setup(props, { emit }) {
-    const buttonClicked = () => {
-      emit("click");
-    };
-    return {
-      buttonClicked,
-    };
+  setup() {
+    return {};
   },
 };
 </script>


### PR DESCRIPTION
関連: https://github.com/vuejs/core/issues/813#issuecomment-597695080

Vue v3は子コンポーネントのルートのネイティブイベントをフォールスルーしてくれる挙動のため、別途カスタムイベントを定義する必要がないらしい