### PR TITLE
docs: /api/pokeapi の廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,6 @@ S3 バケット内のファイルリスト = トレーナーリストであり�
 
 ## API エンドポイント
 
-### `/api/pokeapi`
-
-https://pokeapi.co/api/v2/ へのプロキシー
-
-#### パラメーター
-
-なし
-
-#### レスポンス
-
-https://pokeapi.co/docs/v2 に準じる
-
 ### GET `/api/trainers`
 
 トレーナー名の一覧の取得


### PR DESCRIPTION
https://github.com/webdino/lyceum-pokemon/pull/119/commits/2efc015cb0245313092f909bd59d3d0b6d2d1530 にて実装からは取り除いたのだが消し忘れてしまった。すでに配布済みの内容なので研修期間中は残しておく