### PR TITLE
feat: NUXT_PUBLIC_BACKEND_ORIGIN を省略可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ TBD
 | `AWS_SECRET_ACCESS_KEY`      | AWS 認証情報のシークレットアクセスキー                                          | なし                      |
 | `NUXT_REGION`                | AWS のリージョン                                                                | `"ap-northeast-1"`        |
 | `NUXT_BUCKET_NAME`           | 本アプリケーションのデータ永続化に用いる AWS S3 バケット                        | `""`                      |
-| `NUXT_PUBLIC_BACKEND_ORIGIN` | Nuxt から Express への API リクエストに用いるオリジン[^オリジン以外禁止]        | `"http://localhost:3000"` |
+| `NUXT_PUBLIC_BACKEND_ORIGIN` | Nuxt から Express への API リクエストに用いるオリジン[^オリジン以外禁止]        | なし                      |
 | `HOST` または `NITRO_HOST`   | `npm start` 時反映される Nuxt サーバーのホスト名                                | `"0.0.0.0"`               |
 | `PORT` または `NITRO_PORT`   | `npm start` 時反映される Nuxt サーバーのポート番号                              | `3000`                    |
 | `FRONTEND_ORIGIN`            | Express サーバが CORS を許可するアクセス元オリジン。Nuxt 側のオリジンを設定する | `"http://localhost:3000"` |
@@ -86,7 +86,7 @@ TBD
 | `AWS_SECRET_ACCESS_KEY` [^AWS_クレデンシャル] | :heavy_check_mark:   | :heavy_check_mark:          |                       |
 | `NUXT_REGION` [^他のリージョン]               |                      |                             |                       |
 | `NUXT_BUCKET_NAME` [^AWS_S3_バケット名]       | :heavy_check_mark:   | :heavy_check_mark:          | :heavy_check_mark:    |
-| `NUXT_PUBLIC_BACKEND_ORIGIN`                  |                      | :heavy_check_mark:          | :heavy_check_mark:    |
+| `NUXT_PUBLIC_BACKEND_ORIGIN`                  |                      | :heavy_check_mark:          |                       |
 | `HOST` または `NITRO_HOST`                    |                      |                             | :heavy_check_mark:    |
 | `PORT` または `NITRO_PORT`                    |                      |                             | :heavy_check_mark:    |
 | `FRONTEND_ORIGIN`                             |                      | :heavy_check_mark:          |                       |

--- a/composables/useTrainers.js
+++ b/composables/useTrainers.js
@@ -2,8 +2,10 @@ import { useFetch, useRuntimeConfig } from "#app";
 
 export default () => {
   const config = useRuntimeConfig();
-  const response = useFetch(`${config.public.backendOrigin}/api/trainers`, {
+  const response = useFetch("/api/trainers", {
     default: () => [],
+    server: false,
+    baseURL: config.public.backendOrigin,
   });
   return response;
 };

--- a/docs/hints.md
+++ b/docs/hints.md
@@ -133,14 +133,16 @@ const config = useRuntimeConfig();
 
 // data: リアクティブなレスポンスボディ
 // refresh: 再読み込みする関数
-const { data, refresh } = useFetch(
-  `${config.public.backendOrigin}/api/trainers`,
-);
+const { data, refresh } = useFetch("$/api/trainers", {
+  server: false, // ブラウサ側でのみデータ取得する（単純な実装にしておく目的）
+  baseURL: config.public.backendOrigin, // `npm run dev:express` しないなら省略可
+});
 
 // 動的な URL に対しては文字列を返す関数を引数に渡します
-const { data, refresh } = useFetch(
-  () => `${config.public.backendOrigin}/api/trainer/${trainerName}`,
-);
+const { data, refresh } = useFetch(() => `/api/trainer/${trainerName}`, {
+  server: false, // ブラウサ側でのみデータ取得する（単純な実装にしておく目的）
+  baseURL: config.public.backendOrigin, // `npm run dev:express` しないなら省略可
+});
 ```
 
 参考: https://nuxt.com/docs/getting-started/data-fetching
@@ -161,7 +163,8 @@ const { data, refresh } = useFetch(
 +const config = useRuntimeConfig();
 +const trainerName = ref("");
 +const onSubmit = async () => {
-+  const response = await fetch(`${config.public.backendOrigin}/api/trainer`, {
++  const response = await $fetch("/api/trainer", {
++    baseURL: config.public.backendOrigin, // `npm run dev:express` しないなら省略可
 +    method: "POST",
 +    headers: {
 +      "Content-Type": "application/json",
@@ -169,8 +172,8 @@ const { data, refresh } = useFetch(
 +    body: JSON.stringify({
 +      name: trainerName.value,
 +    }),
-+  });
-+  if (!response.ok) return;
++  }).catch((e) => e); // 正常でないレスポンスステータスやネットワークエラーはエラーが投げられるので取得結果に含める https://github.com/unjs/ofetch#%EF%B8%8F-handling-errors
++  if (response instanceof Error) return; // 取得結果がエラークラスインスタンスなら後続の処理をスキップする
 +  router.push(`/trainer/${trainerName.value}`);
 +};
 +</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,7 +7,7 @@ export default defineNuxtConfig({
     region: "ap-northeast-1",
     bucketName: "",
     public: {
-      backendOrigin: "http://localhost:3000",
+      backendOrigin: undefined,
     },
   },
 });

--- a/pages/new.vue
+++ b/pages/new.vue
@@ -5,7 +5,8 @@ const trainerName = ref("");
 const safeTrainerName = computed(() => trimAvoidCharacters(trainerName.value));
 const valid = computed(() => safeTrainerName.value.length > 0);
 const onSubmit = async () => {
-  const response = await fetch(`${config.public.backendOrigin}/api/trainer`, {
+  const response = await $fetch("/api/trainer", {
+    baseURL: config.public.backendOrigin,
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -13,8 +14,8 @@ const onSubmit = async () => {
     body: JSON.stringify({
       name: safeTrainerName.value,
     }),
-  });
-  if (!response.ok) return;
+  }).catch((e) => e);
+  if (response instanceof Error) return;
   router.push(`/trainer/${safeTrainerName.value}`);
 };
 const { dialog, onOpen, onClose } = useDialog();

--- a/pages/trainer/[name]/catch.vue
+++ b/pages/trainer/[name]/catch.vue
@@ -24,13 +24,14 @@ const onNext = async () => {
   await refresh();
 };
 const onCatch = async (pokemon) => {
-  const response = await fetch(
-    `${config.public.backendOrigin}/api/trainer/${route.params.name}/pokemon/${pokemon.name}`,
+  const response = await $fetch(
+    `/api/trainer/${route.params.name}/pokemon/${pokemon.name}`,
     {
+      baseURL: config.public.backendOrigin,
       method: "PUT",
     },
-  );
-  if (!response.ok) return;
+  ).catch((e) => e);
+  if (response instanceof Error) return;
   router.push(`/trainer/${route.params.name}`);
 };
 const { dialog, onOpen, onClose } = useDialog();

--- a/pages/trainer/[name]/index.vue
+++ b/pages/trainer/[name]/index.vue
@@ -75,7 +75,7 @@ const {
       >マサラタウンにかえる</GamifyButton
     >
     <h2>てもちポケモン</h2>
-    <CatchButton :to="`/trainer/${trainer.name}/catch`"
+    <CatchButton :to="`/trainer/${route.params.name}/catch`"
       >ポケモンをつかまえる</CatchButton
     >
     <GamifyList>

--- a/pages/trainer/[name]/index.vue
+++ b/pages/trainer/[name]/index.vue
@@ -3,19 +3,18 @@ const route = useRoute();
 const router = useRouter();
 const config = useRuntimeConfig();
 const { data: trainer, refresh } = await useFetch(
-  () => `${config.public.backendOrigin}/api/trainer/${route.params.name}`,
+  () => `/api/trainer/${route.params.name}`,
   {
     default: () => [],
+    baseUrl: config.public.backendOrigin,
   },
 );
 const onDelete = async () => {
-  const response = await fetch(
-    `${config.public.backendOrigin}/api/trainer/${route.params.name}`,
-    {
-      method: "DELETE",
-    },
-  );
-  if (!response.ok) return;
+  const response = await $fetch(`/api/trainer/${route.params.name}`, {
+    baseURL: config.public.backendOrigin,
+    method: "DELETE",
+  }).catch((e) => e);
+  if (response instanceof Error) return;
   router.push("/");
 };
 const nickname = ref("");
@@ -24,28 +23,27 @@ const onNickname = async (pokemon) => {
   const index = newTrainer.pokemons.findIndex(({ id }) => id === pokemon.id);
   newTrainer.pokemons[index].nickname = trimAvoidCharacters(nickname.value);
   nickname.value = "";
-  const response = await fetch(
-    `${config.public.backendOrigin}/api/trainer/${route.params.name}`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(newTrainer),
+  const response = await $fetch(`/api/trainer/${route.params.name}`, {
+    baseURL: config.public.backendOrigin,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
     },
-  );
-  if (!response.ok) return;
+    body: JSON.stringify(newTrainer),
+  }).catch((e) => e);
+  if (response instanceof Error) return;
   await refresh();
   onCloseNickname();
 };
 const onRelease = async (pokemonId) => {
   const response = await fetch(
-    `${config.public.backendOrigin}/api/trainer/${route.params.name}/pokemon/${pokemonId}`,
+    `/api/trainer/${route.params.name}/pokemon/${pokemonId}`,
     {
+      baseURL: config.public.backendOrigin,
       method: "DELETE",
     },
-  );
-  if (!response.ok) return;
+  ).catch((e) => e);
+  if (response instanceof Error) return;
   await refresh();
   onCloseRelease();
 };


### PR DESCRIPTION
useFetch は SSR で実行しないようにすることで、
SSR における同一オリジンでのデータ取得時に Nuxt が
管理しているパスかチェックされるのを回避します。

また、NUXT_PUBLIC_BACKEND_ORIGIN（config.public.backend.origin）の 初期値を undefined にします。

指定した値はテンプレート文字列では使用せず、
useFetch か $fetch （つまり ofetch）が提供する baseURL オプションで 参照します。

この変更により、以下のケースで NUXT_PUBLIC_BACKEND_ORIGIN の指定が
不要になります。

- Nuxt 開発サーバーを起動（`npm run dev`）するケース
- App Runner にデプロイするケース