### PR TITLE
fix: トレーナー画面で再読み込みするとトレーナー取得に失敗する

### DIFF
--- a/pages/trainer/[name]/index.vue
+++ b/pages/trainer/[name]/index.vue
@@ -6,6 +6,7 @@ const { data: trainer, refresh } = await useFetch(
   () => `/api/trainer/${route.params.name}`,
   {
     default: () => [],
+    server: false,
     baseUrl: config.public.backendOrigin,
   },
 );


### PR DESCRIPTION
SSR 時に server/api 配下にファイルベースルーティングで
トレーナー取得エンドポイントを定義しておらず Nuxt が
ルートの検知に失敗することが原因

https://github.com/webdino/lyceum-pokemon/pull/134/ の変更もれ