### PR TITLE
ofetch でのプロキシーエージェントの追加方法の見直し

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "ofetch": "^1.4.1",
         "prettier": "^3.4.2",
         "proxy-agent": "^6.5.0",
-        "tsup": "^8.3.6"
+        "tsup": "^8.3.6",
+        "undici": "^6.21.1"
       },
       "engines": {
         "node": "^18 || ^20 || ^22"
@@ -14591,6 +14592,16 @@
         "unplugin": "^2.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
@@ -26344,6 +26355,12 @@
         "magic-string": "^0.30.17",
         "unplugin": "^2.1.0"
       }
+    },
+    "undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "dev": true
     },
     "undici-types": {
       "version": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "ofetch": "^1.4.1",
     "prettier": "^3.4.2",
     "proxy-agent": "^6.5.0",
-    "tsup": "^8.3.6"
+    "tsup": "^8.3.6",
+    "undici": "^6.21.1"
   },
   "packageManager": "npm@11.0.0",
   "private": true,

--- a/server/utils/pokemon.js
+++ b/server/utils/pokemon.js
@@ -1,18 +1,12 @@
 import { ofetch } from "ofetch";
+import { EnvHttpProxyAgent } from "undici";
 
-const createProxyAgent = async () => {
-  if (!(process.env.HTTPS_PROXY || process.env.HTTP_PROXY)) return;
-  const { ProxyAgent } = await import("undici");
-  const dispatcher = new ProxyAgent(
-    process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY,
-  );
-  return dispatcher;
-};
+const envHttpProxyAgent = new EnvHttpProxyAgent();
 
 /** ポケモンの取得 */
 export const findPokemon = async (name) => {
   const pokemon = await ofetch(`https://pokeapi.co/api/v2/pokemon/${name}`, {
-    dispatcher: await createProxyAgent(),
+    dispatcher: envHttpProxyAgent,
   });
   return pokemon;
 };

--- a/server/utils/pokemon.js
+++ b/server/utils/pokemon.js
@@ -1,28 +1,18 @@
 import { ofetch } from "ofetch";
 
-const agentFactory = async () => {
-  if (!(process.env.HTTPS_PROXY || process.env.HTTP_PROXY)) return {};
-  const nodeVer = process.version.match(
-    /^v(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)/,
-  );
-  const nodeMajorVer = Number(nodeVer.groups.major);
-  if (nodeMajorVer < 18) {
-    const { ProxyAgent } = await import("proxy-agent");
-    const agent = new ProxyAgent();
-    return { agent };
-  }
+const createProxyAgent = async () => {
+  if (!(process.env.HTTPS_PROXY || process.env.HTTP_PROXY)) return;
   const { ProxyAgent } = await import("undici");
   const dispatcher = new ProxyAgent(
     process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY,
   );
-  return { dispatcher };
+  return dispatcher;
 };
 
 /** ポケモンの取得 */
 export const findPokemon = async (name) => {
-  const pokemon = await ofetch(
-    `https://pokeapi.co/api/v2/pokemon/${name}`,
-    await agentFactory(),
-  );
+  const pokemon = await ofetch(`https://pokeapi.co/api/v2/pokemon/${name}`, {
+    dispatcher: await createProxyAgent(),
+  });
   return pokemon;
 };

--- a/server/utils/pokemon.js
+++ b/server/utils/pokemon.js
@@ -1,6 +1,8 @@
 import { ofetch } from "ofetch";
 import { EnvHttpProxyAgent } from "undici";
 
+// NOTE: Warning: EnvHttpProxyAgent is experimental, expect them to change at any time
+// See https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent.md
 const envHttpProxyAgent = new EnvHttpProxyAgent();
 
 /** ポケモンの取得 */

--- a/server/utils/pokemon.js
+++ b/server/utils/pokemon.js
@@ -1,11 +1,28 @@
-import { ProxyAgent } from "proxy-agent";
 import { ofetch } from "ofetch";
 
-const agent = new ProxyAgent();
+const agentFactory = async () => {
+  if (!(process.env.HTTPS_PROXY || process.env.HTTP_PROXY)) return {};
+  const nodeVer = process.version.match(
+    /^v(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)/,
+  );
+  const nodeMajorVer = Number(nodeVer.groups.major);
+  if (nodeMajorVer < 18) {
+    const { ProxyAgent } = await import("proxy-agent");
+    const agent = new ProxyAgent();
+    return { agent };
+  }
+  const { ProxyAgent } = await import("undici");
+  const dispatcher = new ProxyAgent(
+    process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY,
+  );
+  return { dispatcher };
+};
+
 /** ポケモンの取得 */
 export const findPokemon = async (name) => {
-  const pokemon = await ofetch(`https://pokeapi.co/api/v2/pokemon/${name}`, {
-    agent,
-  });
+  const pokemon = await ofetch(
+    `https://pokeapi.co/api/v2/pokemon/${name}`,
+    await agentFactory(),
+  );
   return pokemon;
 };


### PR DESCRIPTION
ofetch の agent オプションは Node v18 未満 ~~で動作するみたい~~ を対象に提供されているみたい
~~Node.js のバージョンをチェックし、~~ Undici Dispatcher API を使用する形に見直します

see https://github.com/unjs/ofetch/blob/main/README.md#%EF%B8%8F-adding-https-agent